### PR TITLE
[feature] 처방전 분석 기록 저장 및 조회 API 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const authRouter = require('./routes/auth');
 const bookmarkRouter = require('./routes/bookmark');
 const durRouter = require("./routes/dur");
 const summaryRouter = require("./routes/summary");
+const analysisRouter = require('./routes/analysis');
 
 const app = express();
 
@@ -17,6 +18,7 @@ connectDB();
 const allowedOrigins = [
   'http://localhost:5173',
   'http://127.0.0.1:5173',
+  'http://192.168.200.102:5173',
   process.env.CLIENT_URL,
 ];
 
@@ -39,6 +41,7 @@ app.use('/api/scan', scanRouter);
 app.use('/api/bookmarks', bookmarkRouter);
 app.use("/api/dur", durRouter);
 app.use("/api/summary", summaryRouter);
+app.use('/api/analysis', analysisRouter);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/models/AnalysisRecord.js
+++ b/models/AnalysisRecord.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const analysisRecordSchema = new mongoose.Schema(
+  {
+    userId:         { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    candidates:     [{ type: String }],
+    medicineCount:  { type: Number, default: 0 },
+    cautionCount:   { type: Number, default: 0 }, // durList가 있는 약품 수
+    medicineResults: [{ type: mongoose.Schema.Types.Mixed }],
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('AnalysisRecord', analysisRecordSchema, 'analysisRecord');

--- a/routes/analysis.js
+++ b/routes/analysis.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const router = express.Router();
+const AnalysisRecord = require('../models/AnalysisRecord');
+
+// POST /api/analysis - 분석 결과 저장
+router.post('/', async (req, res) => {
+  try {
+    const { candidates, medicineResults } = req.body;
+
+    if (!medicineResults) {
+      return res.status(400).json({ error: 'medicineResults가 필요합니다.' });
+    }
+
+    const medicineCount = medicineResults.filter(r => r.medicines?.length > 0).length;
+    const cautionCount = medicineResults.filter(r => r.durList?.length > 0).length;
+
+    const record = await AnalysisRecord.create({
+      candidates,
+      medicineCount,
+      cautionCount,
+      medicineResults,
+    });
+
+    return res.json({ recordId: record._id });
+  } catch (err) {
+    console.error('[ANALYSIS SAVE ERROR]', err);
+    res.status(500).json({ error: '저장에 실패했습니다.' });
+  }
+});
+
+// GET /api/analysis - 목록 조회
+router.get('/', async (req, res) => {
+  try {
+    const records = await AnalysisRecord.find()
+      .select('candidates medicineCount cautionCount createdAt')
+      .sort({ createdAt: -1 });
+
+    return res.json(records);
+  } catch (err) {
+    console.error('[ANALYSIS LIST ERROR]', err);
+    res.status(500).json({ error: '목록을 불러오지 못했습니다.' });
+  }
+});
+
+// GET /api/analysis/:id - 상세 조회
+router.get('/:id', async (req, res) => {
+  try {
+    const record = await AnalysisRecord.findById(req.params.id);
+
+    if (!record) return res.status(404).json({ error: '기록을 찾을 수 없습니다.' });
+
+    return res.json(record);
+  } catch (err) {
+    console.error('[ANALYSIS DETAIL ERROR]', err);
+    res.status(500).json({ error: '기록을 불러오지 못했습니다.' });
+  }
+});
+
+module.exports = router;

--- a/routes/analysis.js
+++ b/routes/analysis.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const AnalysisRecord = require('../models/AnalysisRecord');
+const authMiddleware = require('../middleware/auth');
 
 // POST /api/analysis - 분석 결과 저장
-router.post('/', async (req, res) => {
+router.post('/', authMiddleware, async (req, res) => {
   try {
     const { candidates, medicineResults } = req.body;
 
@@ -15,6 +16,7 @@ router.post('/', async (req, res) => {
     const cautionCount = medicineResults.filter(r => r.durList?.length > 0).length;
 
     const record = await AnalysisRecord.create({
+      userId: req.user.id,
       candidates,
       medicineCount,
       cautionCount,
@@ -28,10 +30,10 @@ router.post('/', async (req, res) => {
   }
 });
 
-// GET /api/analysis - 목록 조회
-router.get('/', async (req, res) => {
+// GET /api/analysis - 내 기록 목록 조회
+router.get('/', authMiddleware, async (req, res) => {
   try {
-    const records = await AnalysisRecord.find()
+    const records = await AnalysisRecord.find({ userId: req.user.id })
       .select('candidates medicineCount cautionCount createdAt')
       .sort({ createdAt: -1 });
 
@@ -43,9 +45,12 @@ router.get('/', async (req, res) => {
 });
 
 // GET /api/analysis/:id - 상세 조회
-router.get('/:id', async (req, res) => {
+router.get('/:id', authMiddleware, async (req, res) => {
   try {
-    const record = await AnalysisRecord.findById(req.params.id);
+    const record = await AnalysisRecord.findOne({
+      _id: req.params.id,
+      userId: req.user.id,
+    });
 
     if (!record) return res.status(404).json({ error: '기록을 찾을 수 없습니다.' });
 

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -1,46 +1,25 @@
 const express = require('express');
 const router = express.Router();
 const multer = require('multer');
-const { extractTextFromImage } = require('../models/ocr');
+const { extractTextFromImage } = require('../utils/ocr');
 const { extractMedicines } = require('../utils/gemini');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
-/**
- * POST /api/scan
- * 이미지를 받아 Google Vision OCR로 텍스트를 추출해 반환
- *
- * 현재 응답: { rawText }
- *
- * [다음 작업자를 위한 흐름 참고]
- * 1. services/geminiService.js 생성
- *    - rawText를 Gemini에 전달해 약품명만 추출하는 함수 작성
- *    - 반환 형태: candidates: string[]
- * 2. 아래 흐름으로 scan.js 수정
- *    const candidates = await extractMedicines(rawText);
- *    res.json({ rawText, candidates });
- */
 router.post('/', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) return res.status(400).json({ error: '이미지가 없습니다.' });
 
-    // Step 1: Google Vision OCR로 텍스트 추출
     const rawText = await extractTextFromImage(req.file.buffer);
-
     console.log('[SCAN] rawText:', rawText);
 
-    // Step 2: Gemini 약품명 추출 (미구현 - 다음 작업자)
-     const candidates = await extractMedicines(rawText);
-
+    const candidates = await extractMedicines(rawText);
     console.log('[SCAN] candidates:', candidates);
 
-    return res.json({
-      rawText,
-      candidates,
-    });
+    return res.json({ rawText, candidates });
 
   } catch (err) {
-    console.error(err);
+    console.error('[SCAN ERROR]', err);
     res.status(500).json({ error: '처리 중 오류가 발생했습니다.' });
   }
 });

--- a/services/medicineService.js
+++ b/services/medicineService.js
@@ -1,0 +1,14 @@
+const Medicine = require('../models/Medicine');
+const { fetchMedicineInfo } = require('../utils/medicineApi');
+
+async function getMedicineWithCache(name) {
+  const cached = await Medicine.findOne({ name: { $regex: name, $options: 'i' } });
+  if (cached) return cached;
+
+  const result = await fetchMedicineInfo(name);
+  if (!result) return null;
+
+  return await Medicine.create(result);
+}
+
+module.exports = { getMedicineWithCache };

--- a/services/scanService.js
+++ b/services/scanService.js
@@ -1,0 +1,24 @@
+const { getMedicineWithCache } = require('./medicineService');
+const { fetchDurByProductName } = require('../utils/durApi');
+const { summarizeMedicineBrief } = require('../utils/gemini');
+
+async function processSingleCandidate(keyword) {
+  const medicine = await getMedicineWithCache(keyword);
+  const medicines = medicine ? [medicine] : [];
+
+  const durList = medicine
+    ? await fetchDurByProductName(keyword).catch(() => [])
+    : [];
+
+  const summary = medicine
+    ? await summarizeMedicineBrief({ medicine, durList }).catch(() => '')
+    : '';
+
+  return { keyword, medicines, durList, summary };
+}
+
+async function runScanPipeline(candidates) {
+  return Promise.all(candidates.map(processSingleCandidate));
+}
+
+module.exports = { runScanPipeline };

--- a/utils/ocr.js
+++ b/utils/ocr.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+
+async function extractTextFromImage(imageBuffer) {
+  const base64Image = imageBuffer.toString('base64');
+
+  const response = await axios.post(
+    `https://vision.googleapis.com/v1/images:annotate?key=${process.env.GOOGLE_VISION_API_KEY}`,
+    {
+      requests: [
+        {
+          image: { content: base64Image },
+          features: [{ type: 'TEXT_DETECTION' }],
+        },
+      ],
+    }
+  );
+
+  const text = response.data?.responses?.[0]?.textAnnotations?.[0]?.description ?? '';
+  console.log('[Google Vision OCR] 인식된 텍스트:', text);
+  return text;
+}
+
+async function extractTextFromImageSafe(imageBuffer) {
+  try {
+    return await extractTextFromImage(imageBuffer);
+  } catch (err) {
+    console.error('[Google Vision OCR] 에러 상세:', err.response?.data ?? err.message);
+    throw err;
+  }
+}
+
+module.exports = { extractTextFromImage: extractTextFromImageSafe };


### PR DESCRIPTION
## 개요
처방전 스캔 결과를 DB에 저장하고, 분석 기록 목록/상세 조회가 가능하도록 API를 구현합니다.

## 배경
기존에는 스캔 결과가 프론트 메모리(ocrStore)에만 저장되어 새로고침 시 데이터가 사라지는 문제가 있었습니다.

## API 명세
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | /api/analysis | 분석 결과 저장 → { recordId } 반환 |
| GET | /api/analysis | 목록 조회 (candidates, medicineCount, cautionCount, createdAt) |
| GET | /api/analysis/:id | 단건 상세 조회 |

## 플로우
1. 프론트: scanAndFetchMedicines() 완료
2. POST /api/analysis → DB 저장 → recordId 반환
3. navigate(`/ai-summary/${recordId}`)
4. 히스토리: GET /api/analysis → 목록 표시
5. 클릭: GET /api/analysis/:id → 상세 조회
