### PR TITLE
[feat] 처방전 분석 의약품 조회 및 북마크 API 개선

### DIFF
--- a/models/Medicine.js
+++ b/models/Medicine.js
@@ -9,6 +9,7 @@ const medicineSchema = new mongoose.Schema(
     sideEffect: String, //부작용
     image: String, //이미지 URL
     rawText: String, //OCR 원문
+    dosage: String, // 북마크/목록에서 보여줄 복용법
 
     // 조회 출처
     // easyDrug: e약은요 API
@@ -24,7 +25,10 @@ const medicineSchema = new mongoose.Schema(
     className: String, // 전문/일반 구분
 
     interaction: String,
-    storageMethod: String,
+    productType: String,
+    status: String,
+    ediCode: String,
+    normalizedName: String,
   },
   { timestamps: true },
 );

--- a/models/User.js
+++ b/models/User.js
@@ -2,15 +2,21 @@ const mongoose = require('mongoose');
 
 const bookmarkSchema = new mongoose.Schema(
   {
-    id:       { type: String, required: true },
-    name:     { type: String },
-    engName:  { type: String, default: '' },
+    id: { type: String, required: true },
+    name: { type: String },
+    normalizedName: { type: String, default: "" },
+    engName: { type: String, default: "" },
     category: { type: String },
-    dosage:   { type: String },
-    folder:   { type: String, default: '기타' },
-    starred:  { type: Boolean, default: false },
-    warning:  { type: Boolean, default: false },
-    date:     { type: String },
+    dosage: { type: String },
+
+    folder: {
+      type: [String],
+      default: ["기타"],
+    },
+
+    starred: { type: Boolean, default: false },
+    warning: { type: Boolean, default: false },
+    date: { type: String },
   },
   { id: false }
 );

--- a/routes/bookmark.js
+++ b/routes/bookmark.js
@@ -1,21 +1,21 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const mongoose = require('mongoose');
-const User = require('../models/User');
-const Medicine = require('../models/Medicine');
-const auth = require('../middleware/auth');
+const mongoose = require("mongoose");
+const User = require("../models/User");
+const Medicine = require("../models/Medicine");
+const auth = require("../middleware/auth");
 
 // 북마크 목록 조회
-router.get('/', auth, async (req, res) => {
+router.get("/", auth, async (req, res) => {
   try {
     if (!req.user || !req.user.id) {
-      return res.status(401).json({ message: '인증이 필요합니다.' });
+      return res.status(401).json({ message: "인증이 필요합니다." });
     }
 
     const user = await User.findById(req.user.id);
 
     if (!user) {
-      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
     }
 
     const bookmarks = user.bookmarks || [];
@@ -26,69 +26,73 @@ router.get('/', auth, async (req, res) => {
         const obj = b.toObject();
         return {
           ...obj,
-          name:     med?.name     || obj.name     || '',
-          engName:  med?.normalizedName || obj.engName  || '',
-          category: med?.effect   || obj.category || '',
-          dosage:   med?.dosage   || obj.dosage   || '',
-          warning:  Array.isArray(med?.sideEffect) && med.sideEffect.length > 0,
+          name: med?.name || obj.name || "",
+          normalizedName: med?.normalizedName || obj.normalizedName || "",
+          engName: med?.normalizedName || obj.engName || "",
+          category: med?.effect || obj.category || "",
+          dosage: med?.dosage || med?.usage || obj.dosage || "",
+          warning: Boolean(med?.sideEffect || obj.warning),
         };
-      })
+      }),
     );
 
     return res.json(populated);
   } catch (error) {
-    console.error('북마크 목록 조회 에러:', error);
-    return res.status(500).json({ message: '서버 오류' });
+    console.error("북마크 목록 조회 에러:", error);
+    return res.status(500).json({ message: "서버 오류" });
   }
 });
 
 // 북마크 추가
-router.post('/', auth, async (req, res) => {
+router.post("/", auth, async (req, res) => {
   try {
-    const { id, folder = '기타' } = req.body;
+    const { id, folder = "기타" } = req.body;
 
     if (!id) {
-      return res.status(400).json({ message: 'id가 필요합니다.' });
+      return res.status(400).json({ message: "id가 필요합니다." });
     }
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return res.status(400).json({ message: '유효하지 않은 id입니다.' });
+      return res.status(400).json({ message: "유효하지 않은 id입니다." });
     }
 
     if (!req.user || !req.user.id) {
-      return res.status(401).json({ message: '인증이 필요합니다.' });
+      return res.status(401).json({ message: "인증이 필요합니다." });
     }
 
     const medicine = await Medicine.findById(id);
 
     if (!medicine) {
-      return res.status(404).json({ message: '약 정보를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "약 정보를 찾을 수 없습니다." });
     }
 
     const user = await User.findById(req.user.id);
 
     if (!user) {
-      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
     }
 
-    const exists = user.bookmarks.some((bookmark) => bookmark.id === String(medicine._id));
+    const exists = user.bookmarks.some(
+      (bookmark) => bookmark.id === String(medicine._id),
+    );
 
     if (exists) {
-      return res.status(409).json({ message: '이미 북마크한 약입니다.' });
+      return res.status(409).json({ message: "이미 북마크한 약입니다." });
     }
 
     const now = new Date();
-    const date = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')}`;
+    const date = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, "0")}.${String(now.getDate()).padStart(2, "0")}`;
 
     const bookmarkData = {
-      id:       String(medicine._id),
-      name:     medicine.name || '',
-      engName:  medicine.normalizedName || '',
-      category: medicine.effect || '',
-      dosage:   medicine.dosage || '',
+      id: String(medicine._id),
+      name: medicine.name || "",
+      normalizedName: medicine.normalizedName || "",
+      engName: medicine.normalizedName || "",
+      category: medicine.effect || "",
+      dosage: medicine.dosage || medicine.usage || "",
       folder,
-      starred:  false,
-      warning:  Array.isArray(medicine.sideEffect) && medicine.sideEffect.length > 0,
+      starred: false,
+      warning: Boolean(medicine.sideEffect),
       date,
     };
 
@@ -96,69 +100,69 @@ router.post('/', auth, async (req, res) => {
     await user.save();
 
     return res.status(201).json({
-      message: '북마크 추가 성공',
+      message: "북마크 추가 성공",
       bookmarks: user.bookmarks,
     });
   } catch (error) {
-    console.error('북마크 추가 에러:', error);
-    return res.status(500).json({ message: '서버 오류' });
+    console.error("북마크 추가 에러:", error);
+    return res.status(500).json({ message: "서버 오류" });
   }
 });
 
 // 북마크 삭제
-router.delete('/:id', auth, async (req, res) => {
+router.delete("/:id", auth, async (req, res) => {
   try {
     if (!req.user || !req.user.id) {
-      return res.status(401).json({ message: '인증이 필요합니다.' });
+      return res.status(401).json({ message: "인증이 필요합니다." });
     }
 
     const user = await User.findById(req.user.id);
 
     if (!user) {
-      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
     }
 
     const beforeLength = user.bookmarks.length;
 
     user.bookmarks = user.bookmarks.filter(
-      (bookmark) => bookmark.id !== req.params.id
+      (bookmark) => bookmark.id !== req.params.id,
     );
 
     if (beforeLength === user.bookmarks.length) {
-      return res.status(404).json({ message: '북마크를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "북마크를 찾을 수 없습니다." });
     }
 
     await user.save();
 
     return res.json({
-      message: '북마크 삭제 성공',
+      message: "북마크 삭제 성공",
       bookmarks: user.bookmarks,
     });
   } catch (error) {
-    console.error('북마크 삭제 에러:', error);
-    return res.status(500).json({ message: '서버 오류' });
+    console.error("북마크 삭제 에러:", error);
+    return res.status(500).json({ message: "서버 오류" });
   }
 });
 
 // 폴더 이동 / 즐겨찾기 토글
-router.patch('/:id', auth, async (req, res) => {
+router.patch("/:id", auth, async (req, res) => {
   try {
     const { folder, starred } = req.body;
 
     if (!req.user || !req.user.id) {
-      return res.status(401).json({ message: '인증이 필요합니다.' });
+      return res.status(401).json({ message: "인증이 필요합니다." });
     }
 
     const user = await User.findById(req.user.id);
 
     if (!user) {
-      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
     }
 
     const bookmark = user.bookmarks.find((b) => b.id === req.params.id);
 
     if (!bookmark) {
-      return res.status(404).json({ message: '북마크를 찾을 수 없습니다.' });
+      return res.status(404).json({ message: "북마크를 찾을 수 없습니다." });
     }
 
     if (folder !== undefined) bookmark.folder = folder;
@@ -167,12 +171,12 @@ router.patch('/:id', auth, async (req, res) => {
     await user.save();
 
     return res.json({
-      message: '북마크 수정 성공',
+      message: "북마크 수정 성공",
       bookmarks: user.bookmarks,
     });
   } catch (error) {
-    console.error('북마크 수정 에러:', error);
-    return res.status(500).json({ message: '서버 오류' });
+    console.error("북마크 수정 에러:", error);
+    return res.status(500).json({ message: "서버 오류" });
   }
 });
 

--- a/routes/dur.js
+++ b/routes/dur.js
@@ -6,6 +6,13 @@ const {
   fetchDurByProductName,
 } = require("../utils/durApi");
 
+const normalizeProductName = (name = "") =>
+  String(name)
+    .replace(/\([^)]*\)/g, "") // 괄호 안 성분명 제거
+    .replace(/\[[^\]]*\]/g, "") // 대괄호 내용 제거
+    .replace(/\s+/g, " ")
+    .trim();
+
 /**
  * GET /api/dur/ingredient?name=Metoclopramide
  * 성분명 기준 DUR 병용금기 조회
@@ -47,7 +54,12 @@ router.get("/product", async (req, res) => {
       });
     }
 
-    const result = await fetchDurByProductName(name);
+    const productName = normalizeProductName(name);
+
+    console.log("[DUR PRODUCT RAW NAME]", name);
+    console.log("[DUR PRODUCT NORMALIZED NAME]", productName);
+
+    const result = await fetchDurByProductName(productName);
 
     return res.json(result);
   } catch (err) {

--- a/routes/medicine.js
+++ b/routes/medicine.js
@@ -3,6 +3,20 @@ const router = express.Router();
 const { fetchMedicineInfo } = require('../utils/medicineApi');
 const Medicine = require('../models/Medicine');
 
+const escapeRegex = (value = "") => {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
+const cleanMedicineKeyword = (value = "") => {
+  const text = String(value).trim();
+
+  const matched = text.match(
+    /[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)/
+  );
+
+  return matched?.[0] || text.split(/\s|\[/)[0];
+};
+
 /**
  * GET /api/medicine?q=약품명
  * 약품명으로 DB 검색 후 없으면 식약처 API 조회해서 저장 후 반환
@@ -12,27 +26,28 @@ const Medicine = require('../models/Medicine');
  *   각 약품명마다 이 API를 호출하면 됨
  *   예: candidates.forEach(name => GET /api/medicine?q=name)
  */
-router.get('/', async (req, res) => {
+router.get("/", async (req, res) => {
   try {
     const { q, refresh } = req.query;
 
-    const shouldRefresh = refresh === 'true';
-    const filter = q ? { name: { $regex: q, $options: 'i' } } : {};
+    const keyword = q ? cleanMedicineKeyword(q) : "";
+    const escapedKeyword = escapeRegex(keyword);
+
+    const filter = keyword
+      ? { name: { $regex: escapedKeyword, $options: "i" } }
+      : {};
 
     let medicines = [];
 
-    // refresh=true가 아닐 때만 DB 먼저 조회
-    if (!shouldRefresh) {
+    if (!refresh) {
       medicines = await Medicine.find(filter).sort({ createdAt: -1 });
     }
 
-    // DB에 없거나 refresh=true이면 식약처 API 재조회
-    if ((medicines.length === 0 || shouldRefresh) && q) {
-      const result = await fetchMedicineInfo(q);
+    if ((medicines.length === 0 && keyword) || refresh) {
+      const result = await fetchMedicineInfo(keyword);
 
       if (result) {
-        // refresh=true이면 기존 저장 데이터 삭제 후 새로 저장
-        if (shouldRefresh) {
+        if (refresh) {
           await Medicine.deleteMany(filter);
         }
 
@@ -41,13 +56,12 @@ router.get('/', async (req, res) => {
       }
     }
 
-    res.set('Cache-Control', 'no-store');
+    res.set("Cache-Control", "no-store");
     return res.json(medicines);
   } catch (err) {
-    console.error('[MEDICINE ROUTE ERROR]', err);
-
+    console.error(err);
     return res.status(500).json({
-      error: '데이터를 불러오지 못했습니다.',
+      error: "데이터를 불러오지 못했습니다.",
       message: err.message,
     });
   }

--- a/routes/medicine.js
+++ b/routes/medicine.js
@@ -28,26 +28,32 @@ const cleanMedicineKeyword = (value = "") => {
  */
 router.get("/", async (req, res) => {
   try {
-    const { q, refresh } = req.query;
+    const { q } = req.query;
+    const shouldRefresh = req.query.refresh === "true" || req.query.refresh === "1";
 
     const keyword = q ? cleanMedicineKeyword(q) : "";
+
+    if (!keyword) {
+      return res.json([]);
+    }
+
     const escapedKeyword = escapeRegex(keyword);
 
-    const filter = keyword
-      ? { name: { $regex: escapedKeyword, $options: "i" } }
-      : {};
+    const filter = {
+      name: { $regex: escapedKeyword, $options: "i" },
+    };
 
     let medicines = [];
 
-    if (!refresh) {
+    if (!shouldRefresh) {
       medicines = await Medicine.find(filter).sort({ createdAt: -1 });
     }
 
-    if ((medicines.length === 0 && keyword) || refresh) {
+    if (medicines.length === 0 || shouldRefresh) {
       const result = await fetchMedicineInfo(keyword);
 
       if (result) {
-        if (refresh) {
+        if (shouldRefresh) {
           await Medicine.deleteMany(filter);
         }
 

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -36,11 +36,73 @@ router.post("/", upload.single("image"), async (req, res) => {
     let candidates = [];
     let usedFallback = false;
 
-    const cleanMedicineName = (value = "") => {
-      const text = String(value).trim();
+    const BLOCK_WORDS = [
+      "환자",
+      "가정",
+      "메디홈",
+      "약제비",
+      "총액",
+      "전액",
+      "금액",
+      "수납",
+      "본인부담",
+      "보험",
+      "처방",
+      "조제",
+      "복용",
+      "용법",
+      "용량",
+      "일수",
+      "투약",
+      "필름코팅",
+      "코팅정",
+      "완화시켜",
+    ];
 
+    const DOSAGE_ONLY_WORDS = [
+      "정",
+      "1정",
+      "2정",
+      "3정",
+      "전액",
+      "필름코팅정",
+      "코팅정",
+      "캡슐",
+      "시럽",
+      "현탁액",
+      "과립",
+      "연고",
+      "크림",
+    ];
+
+    const cleanMedicineName = (value = "") => {
+      const text = String(value)
+        .replace(/\s+/g, "")
+        .replace(/[()[\]{}]/g, "")
+        .trim();
+
+      if (!text) return "";
+
+      // 너무 짧은 값 제거: 1정, 정, 전액 같은 값 방지
+      if (text.length < 3) return "";
+
+      // 숫자 + 제형만 있는 값 제거
+      if (/^\d+(정|캡슐|포|병|회|일|mg|ml)$/i.test(text)) return "";
+
+      // 금액/환자/문장성 단어 제거
+      if (BLOCK_WORDS.some((word) => text.includes(word))) return "";
+
+      // 제형만 있는 단어 제거
+      if (DOSAGE_ONLY_WORDS.includes(text)) return "";
+
+      /**
+       * 주의:
+       * - "주" 단독은 제거해야 함. "완화시켜주" 같은 문장이 잡힘.
+       * - "액"은 전액/금액 때문에 위험하지만, 실제 약품명에도 쓰일 수 있어서
+       *   위 BLOCK_WORDS로 먼저 걸러낸 뒤 제한적으로 허용.
+       */
       const matched = text.match(
-        /[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)/,
+        /[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|크림|연고|겔|패취|점안액)$/,
       );
 
       return matched?.[0] || "";
@@ -67,13 +129,6 @@ router.post("/", upload.single("image"), async (req, res) => {
       rawText,
       candidates,
       usedFallback,
-    });
-
-    console.log("[SCAN] candidates:", candidates);
-
-    return res.json({
-      rawText,
-      candidates,
     });
   } catch (err) {
     console.error(err);

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -1,8 +1,11 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const multer = require('multer');
-const { extractTextFromImage } = require('../models/ocr');
-const { extractMedicines } = require('../utils/gemini');
+const multer = require("multer");
+const { extractTextFromImage } = require("../models/ocr");
+const {
+  extractMedicines,
+  extractMedicinesFallback,
+} = require("../utils/gemini");
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -20,28 +23,61 @@ const upload = multer({ storage: multer.memoryStorage() });
  *    const candidates = await extractMedicines(rawText);
  *    res.json({ rawText, candidates });
  */
-router.post('/', upload.single('image'), async (req, res) => {
+router.post("/", upload.single("image"), async (req, res) => {
   try {
-    if (!req.file) return res.status(400).json({ error: '이미지가 없습니다.' });
+    if (!req.file) return res.status(400).json({ error: "이미지가 없습니다." });
 
     // Step 1: Google Vision OCR로 텍스트 추출
     const rawText = await extractTextFromImage(req.file.buffer);
 
-    console.log('[SCAN] rawText:', rawText);
+    console.log("[SCAN] rawText:", rawText);
 
     // Step 2: Gemini 약품명 추출 (미구현 - 다음 작업자)
-     const candidates = await extractMedicines(rawText);
+    let candidates = [];
+    let usedFallback = false;
 
-    console.log('[SCAN] candidates:', candidates);
+    const cleanMedicineName = (value = "") => {
+      const text = String(value).trim();
+
+      const matched = text.match(
+        /[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)/,
+      );
+
+      return matched?.[0] || "";
+    };
+
+    const normalizeCandidates = (candidates = []) => {
+      return [...new Set(candidates.map(cleanMedicineName).filter(Boolean))];
+    };
+
+    try {
+      candidates = await extractMedicines(rawText);
+    } catch (geminiErr) {
+      console.error("[GEMINI MEDICINE EXTRACT ERROR]", geminiErr.message);
+
+      candidates = extractMedicinesFallback(rawText);
+      usedFallback = true;
+    }
+
+    candidates = normalizeCandidates(candidates);
+
+    console.log("[SCAN] candidates:", candidates);
+
+    return res.json({
+      rawText,
+      candidates,
+      usedFallback,
+    });
+
+    console.log("[SCAN] candidates:", candidates);
 
     return res.json({
       rawText,
       candidates,
     });
-
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: '처리 중 오류가 발생했습니다.' });
+    res.status(500).json({ error: "처리 중 오류가 발생했습니다." });
   }
 });
 

--- a/routes/summary.js
+++ b/routes/summary.js
@@ -1,8 +1,57 @@
 const express = require("express");
 const router = express.Router();
 
-const { summarizeMedicineBrief } = require("../utils/gemini");
+const {
+  summarizeMedicineBrief,
+  summarizeMedicinesBrief,
+} = require("../utils/gemini");
 
+const makeEasyFallbackSummary = (medicine = {}) => {
+  const text = [
+    medicine.effect,
+    medicine.usage,
+    medicine.caution,
+    medicine.interaction,
+    medicine.sideEffect,
+    medicine.storageMethod,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const hasDurWarnings =
+    Array.isArray(medicine.durWarnings) && medicine.durWarnings.length > 0;
+
+  if (hasDurWarnings) {
+    return "함께 먹으면 주의가 필요한 약이 있을 수 있어 복용 전 확인하세요.";
+  }
+
+  if (medicine.source === "permit") {
+    return "제품 허가정보 기준으로 확인됐으며, 복용법과 부작용은 처방전이나 약사 안내를 확인하세요.";
+  }
+
+  if (/졸음|운전|기계/.test(text)) {
+    return "졸음이 올 수 있으니 운전이나 기계 조작 전에는 주의하세요.";
+  }
+
+  if (/과민|알레르기|녹내장|전립선|간질|배뇨|소변/.test(text)) {
+    return "알레르기나 특정 질환이 있다면 복용 전 약사에게 확인하세요.";
+  }
+
+  if (/보관|실온|차광|밀폐/.test(text)) {
+    return "복용 전 안내사항을 확인하고 정해진 방법대로 보관하세요.";
+  }
+
+  return "복용 전 처방전이나 약사 안내를 확인하고, 이상 증상이 있으면 복용을 중단하세요.";
+};
+
+const makeFallbackSummaries = (medicines = []) =>
+  medicines.map((medicine, index) => ({
+    id: String(medicine.id ?? index),
+    keyword: medicine.keyword || medicine.name || "",
+    summary: makeEasyFallbackSummary(medicine),
+  }));
+
+// 기존: 약 1개 요약
 router.post("/medicine", async (req, res) => {
   try {
     const { medicine, durList } = req.body;
@@ -19,14 +68,43 @@ router.post("/medicine", async (req, res) => {
       durList: durList || [],
     });
 
+    console.log("[PRESCRIPTION SUMMARY RESULT]", summary);
+
     return res.json({ summary });
   } catch (err) {
     console.error("[SUMMARY ERROR]", err);
 
-    // 요약은 부가 기능이므로 실패해도 전체 분석을 막지 않음
     return res.json({
       summary: "",
       summaryError: true,
+    });
+  }
+});
+
+// 추가: 약 여러 개를 한 번에 요약
+router.post("/medicines", async (req, res) => {
+  try {
+    const { medicines } = req.body;
+
+    if (!Array.isArray(medicines) || medicines.length === 0) {
+      return res.status(400).json({
+        message: "medicines 배열 데이터가 필요합니다.",
+        summaries: [],
+      });
+    }
+
+    const summaries = await summarizeMedicinesBrief(medicines);
+
+    return res.json({ summaries });
+  } catch (err) {
+    console.error("[SUMMARY BULK ERROR]", err);
+
+    const fallbackSummaries = makeFallbackSummaries(req.body.medicines || []);
+
+    return res.json({
+      summaries: fallbackSummaries,
+      summaryError: true,
+      fallback: true,
     });
   }
 });

--- a/utils/durApi.js
+++ b/utils/durApi.js
@@ -213,17 +213,20 @@ async function fetchDurByProductName(itemName) {
   try {
     console.log("[DUR PRODUCT QUERY]", itemName);
 
-    const serviceKey = API_KEY.includes("%")
-      ? decodeURIComponent(API_KEY)
-      : API_KEY;
+    const getServiceKey = () => {
+      if (!API_KEY) return "";
+      return API_KEY.includes("%") ? decodeURIComponent(API_KEY) : API_KEY;
+    };
+
+    const serviceKey = getServiceKey();
 
     const res = await axios.get(DUR_PRODUCT_CONTRA_URL, {
       params: {
         serviceKey,
-        pageNo: 1,
-        numOfRows: 100,
-        type: "json",
         itemName,
+        numOfRows: 100,
+        pageNo: 1,
+        type: "json",
       },
     });
 
@@ -239,11 +242,7 @@ async function fetchDurByProductName(itemName) {
     console.error("[DUR PRODUCT API ERROR DATA]", err.response?.data);
     console.error("[DUR PRODUCT API ERROR MESSAGE]", err.message);
 
-    throw new Error(
-      `DUR 품목정보 API 요청 실패: ${err.response?.status || ""} ${
-        err.response?.data || err.message
-      }`,
-    );
+    return [];
   }
 }
 

--- a/utils/gemini.js
+++ b/utils/gemini.js
@@ -1,222 +1,266 @@
 // utils/gemini.js
 
+const axios = require("axios");
+
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
-const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash-lite";
 
-const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
+const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
 
-const buildPrompt = (rawText) => `
-너는 OCR로 추출된 약 봉투, 처방전, 약품 설명서 텍스트에서
-식약처 API 검색에 사용할 약품명 후보만 추출한다.
+const requestGemini = async (
+  prompt,
+  { json = false, maxOutputTokens = 500 } = {},
+) => {
+  if (!prompt || typeof prompt !== "string") {
+    throw new Error("Gemini prompt가 비어 있습니다.");
+  }
 
-규칙:
-1. OCR 원문에 없는 약품명은 추측하지 않는다.
-2. 병원명, 약국명, 주소, 전화번호, 보험자명, 환자명은 제외한다.
-3. "1일 3회", "식후", "복용", "처방", "조제" 같은 복약 안내 문구는 제외한다.
-4. 실제 약품명 또는 성분명으로 보이는 값만 candidates 배열에 넣는다.
-5. 중복은 제거한다.
-6. 확실한 후보가 없으면 빈 배열을 반환한다.
-7. 반드시 JSON 형식으로만 응답한다.
+  try {
+    const generationConfig = {
+      temperature: 0.1,
+      maxOutputTokens,
+    };
 
-응답 형식:
-{
-  "candidates": ["약품명1", "약품명2"]
-}
+    if (json) {
+      generationConfig.responseMimeType = "application/json";
+    }
 
-OCR 원문:
+    const response = await axios.post(
+      GEMINI_URL,
+      {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        timeout: 60000,
+      },
+    );
+
+    return response.data?.candidates?.[0]?.content?.parts?.[0]?.text || "";
+  } catch (error) {
+    console.error("[GEMINI ERROR]", error.response?.data || error.message);
+    throw new Error("Gemini API 요청에 실패했습니다.");
+  }
+};
+
+// 기존에 있던 extractMedicines 함수 유지
+const extractMedicines = async (rawText) => {
+  const prompt = `
+다음 OCR 텍스트에서 의약품명만 추출해줘.
+
+조건:
+- 반드시 JSON 배열만 반환해.
+- 설명 문장 쓰지 마.
+- 마크다운 코드블록 쓰지 마.
+- 약품명으로 보이는 항목만 반환해.
+
+OCR 텍스트:
 ${rawText}
 `;
 
-const buildSummaryPrompt = ({ medicine, durList = [] }) => `
-너는 사용자가 의약품 정보를 빠르게 이해할 수 있도록 한 줄로 정리한다.
+  const text = await requestGemini(prompt, {
+    json: true,
+    maxOutputTokens: 300,
+  });
 
-반드시 아래 JSON 데이터에 있는 내용만 근거로 작성한다.
-데이터에 없는 효능, 복용법, 부작용, 주의사항, 병용금기 정보는 절대 추측하지 않는다.
+  const cleanedText = String(text)
+    .replace(/```json/g, "")
+    .replace(/```/g, "")
+    .trim();
 
-규칙:
-1. 한국어로 작성한다.
-2. 한 문장만 작성한다.
-3. 90자 이내로 작성한다.
-4. 쉬운 말로 작성한다.
-5. 병용금기 정보가 있으면 반드시 포함한다.
-6. 병용금기 정보가 없으면 억지로 언급하지 않는다.
-7. "안전하다", "문제없다" 같은 단정 표현은 쓰지 않는다.
-8. 반드시 JSON 형식으로만 응답한다.
+  const parsed = JSON.parse(cleanedText);
 
-응답 형식:
-{
-  "summary": "한 줄 요약 문장"
-}
+  return Array.isArray(parsed) ? parsed : [];
+};
 
-의약품 데이터:
+// 기존 fallback 함수 유지
+const extractMedicinesFallback = (rawText = "") => {
+  const matches = String(rawText).match(
+    /[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)/g,
+  );
+
+  return [...new Set(matches || [])];
+};
+
+// 기존 약 1개 요약 함수 유지
+const summarizeMedicineBrief = async ({ medicine, durList = [] }) => {
+  const prompt = `
+다음 의약품 정보를 간단히 요약해줘.
+
+조건:
+- 2~4문장 정도로 짧게 작성해.
+- 주의사항, 보관방법, 복용 관련 핵심 정보를 포함해.
+- 확인되지 않는 내용은 단정하지 마.
+
+의약품 정보:
 ${JSON.stringify({ medicine, durList }, null, 2)}
 `;
 
-const parseCandidates = (text) => {
-  const cleaned = text
-    .replace(/```json/g, '')
-    .replace(/```/g, '')
+  const text = await requestGemini(prompt, {
+    maxOutputTokens: 250,
+  });
+
+  return String(text).trim();
+};
+
+const normalizeSummaryText = (text = "") =>
+  String(text)
+    .replace(/\.\.\./g, "")
+    .replace(/…/g, "")
+    .replace(/\s+/g, " ")
     .trim();
 
-  const parsed = JSON.parse(cleaned);
-
-  if (!Array.isArray(parsed.candidates)) {
+// 새로 추가한 약 여러 개 일괄 요약 함수
+const summarizeMedicinesBrief = async (medicines = []) => {
+  if (!Array.isArray(medicines) || medicines.length === 0) {
     return [];
   }
 
-  return [
-    ...new Set(
-      parsed.candidates
-        .map((item) => String(item).trim())
-        .filter(Boolean)
-    ),
-  ];
-};
+  const prompt = `
+아래는 요약용으로 축약된 의약품 데이터다.
+각 약마다 사용자가 복용 전 확인해야 할 내용을 쉬운 말로 한 문장 요약해라.
 
-const parseSummary = (text) => {
-  const cleaned = text
-    .replace(/```json/g, '')
-    .replace(/```/g, '')
+조건:
+- 반드시 JSON 배열만 반환해라.
+- 마크다운 코드블록을 사용하지 마라.
+- JSON 밖에 설명 문장을 쓰지 마라.
+- 각 항목은 반드시 id, keyword, summary를 포함해라.
+- id는 입력받은 id와 정확히 같은 값으로 반환해라.
+- keyword는 입력받은 keyword와 정확히 같은 값으로 반환해라.
+
+summary 작성 규칙:
+- 한국어 한 문장으로 작성해라.
+- 100자 이내로 작성해라.
+- 초등학생도 이해할 수 있는 쉬운 말로 작성해라.
+- 식약처 원문 문장을 그대로 복사하지 마라.
+- 어려운 의학 용어는 쉬운 말로 바꿔라.
+- 말줄임표(...)를 절대 사용하지 마라.
+- 문장을 중간에서 끊지 말고 완성된 문장으로 끝내라.
+- 효능 설명보다 복용 전 주의할 점을 우선해라.
+
+durWarnings가 있는 경우:
+- 절대 "다른 약과 함께 먹으면 위험할 수 있다"처럼 막연하게 쓰지 마라.
+- 반드시 relatedIngredientKor 또는 relatedIngredientEng 성분명을 포함해라.
+- 반드시 content의 위험 이유를 쉬운 말로 바꿔 포함해라.
+- 반드시 사용자가 해야 할 행동을 포함해라.
+- 형식은 가능하면 "OO 성분과 함께 복용하면 XX 위험이 커질 수 있어 복용 전 확인하세요."처럼 작성해라.
+- "QTc 연장", "Torsade de Pointes", "심실성 부정맥"은 "심장 리듬 이상" 또는 "심장 박동 이상"으로 바꿔라.
+- "병용금기"는 "함께 복용하면 안 되는 조합" 또는 "함께 복용 주의"로 쉽게 바꿔라.
+
+source가 permit인 경우:
+- 제품 허가정보만으로 확인된 약이라는 점을 반영해라.
+- 단, durWarnings가 있으면 제품 허가정보 문구보다 병용 주의 내용을 우선해라.
+- durWarnings가 없고 복용법, 부작용 정보가 부족하면 처방전 또는 약사 안내 확인이 필요하다고 표현해라.
+
+금지 표현:
+- "다른 약과 함께 먹으면 위험할 수 있으니 약사에게 꼭 확인하세요."
+- "함께 먹으면 주의가 필요한 약이 있을 수 있습니다."
+- "복용 전 확인이 필요합니다."
+- "주의가 필요합니다."만 단독으로 쓰지 마라.
+- "위험할 수 있습니다"처럼 이유 없이 막연하게 쓰지 마라.
+
+좋은 예시:
+[
+  {
+    "id": "0",
+    "keyword": "맥페란정",
+    "summary": "돔페리돈 성분 약과 함께 먹으면 심장 박동 이상 위험이 커질 수 있어 확인하세요."
+  },
+  {
+    "id": "1",
+    "keyword": "보나링에이정",
+    "summary": "졸음이 올 수 있어 운전이나 기계 조작 전에는 복용 여부를 확인하세요."
+  }
+]
+
+반환 형식:
+[
+  {
+    "id": "0",
+    "keyword": "약 이름",
+    "summary": "복용 전 확인할 쉬운 주의사항"
+  }
+]
+
+의약품 목록:
+${JSON.stringify(medicines)}
+`;
+
+  const text = await requestGemini(prompt, {
+    json: true,
+    maxOutputTokens: 600,
+  });
+
+  const cleanedText = String(text)
+    .replace(/```json/g, "")
+    .replace(/```/g, "")
     .trim();
 
-  const parsed = JSON.parse(cleaned);
+  try {
+    const parsed = JSON.parse(cleanedText);
 
-  if (!parsed.summary) {
-    return '';
-  }
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
 
-  return String(parsed.summary).trim();
-};
+    return parsed.map((item) => ({
+      id: String(item.id ?? ""),
+      keyword: item.keyword || "",
+      summary: normalizeSummaryText(item.summary || ""),
+    }));
+  } catch (error) {
+    console.error("[SUMMARY JSON PARSE ERROR]", {
+      text: cleanedText,
+      message: error.message,
+    });
 
-const requestGemini = async ({ prompt, responseSchema }) => {
-  if (!GEMINI_API_KEY) {
-    throw new Error('GEMINI_API_KEY가 설정되지 않았습니다.');
-  }
-
-  const response = await fetch(GEMINI_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-goog-api-key': GEMINI_API_KEY,
-    },
-    body: JSON.stringify({
-      contents: [
-        {
-          parts: [
-            {
-              text: prompt,
-            },
-          ],
-        },
-      ],
-      generationConfig: {
-        temperature: 0.1,
-        responseMimeType: 'application/json',
-        responseSchema,
-      },
-    }),
-  });
-
-  const data = await response.json();
-
-  if (!response.ok) {
-    console.error('[GEMINI ERROR]', data);
-    throw new Error('Gemini API 요청에 실패했습니다.');
-  }
-
-  return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-};
-
-const extractMedicines = async (rawText) => {
-  if (!rawText || !rawText.trim()) {
     return [];
   }
-
-  const text = await requestGemini({
-    prompt: buildPrompt(rawText),
-    responseSchema: {
-      type: 'OBJECT',
-      properties: {
-        candidates: {
-          type: 'ARRAY',
-          items: {
-            type: 'STRING',
-          },
-        },
-      },
-      required: ['candidates'],
-    },
-  });
-
-  if (!text) {
-    return [];
-  }
-
-  return parseCandidates(text);
 };
 
-const extractMedicinesFallback = (rawText) => {
-  if (!rawText || !rawText.trim()) return [];
-
-  const medicinePattern =
-    /[#]?[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)(?:\s?\[[^\]]+\])?/g;
-
-  const matches = rawText.match(medicinePattern) || [];
-
-  const excludeWords = [
-    "복약지도",
-    "약품명",
-    "먹는약",
-    "영수증",
-    "조제약",
-    "처방약",
-    "현금영수증",
-    "사업자등록번호",
-  ];
-
-  return [
-    ...new Set(
-      matches
-        .map((item) =>
-          item
-            .replace(/^#/, "")
-            .replace(/\s?\[.*?\]/g, "")
-            .trim()
-        )
-        .filter(Boolean)
-        .filter((item) => item.length >= 2)
-        .filter((item) => !excludeWords.some((word) => item.includes(word)))
-    ),
-  ];
-};
-
-const summarizeMedicineBrief = async ({ medicine, durList = [] }) => {
-  if (!medicine) {
-    return '';
+const summarizePrescriptionBrief = async ({ medicines = [], durList = [] }) => {
+  if (!Array.isArray(medicines) || medicines.length === 0) {
+    return "";
   }
 
-  const text = await requestGemini({
-    prompt: buildSummaryPrompt({ medicine, durList }),
-    responseSchema: {
-      type: 'OBJECT',
-      properties: {
-        summary: {
-          type: 'STRING',
-        },
-      },
-      required: ['summary'],
-    },
+  const prompt = `
+아래 의약품 목록을 바탕으로 사용자가 복용 전 확인해야 할 핵심 내용을 짧게 요약해라.
+
+조건:
+- 한국어로 작성해라.
+- 2~4문장으로 작성해라.
+- 너무 길게 쓰지 마라.
+- 효능 설명보다 주의사항, 복용 확인, 병용 주의 정보를 우선해라.
+- durList가 있으면 함께 복용 주의가 필요한 성분이 있다는 내용을 포함해라.
+- 제공된 데이터에 없는 내용은 추측하지 마라.
+- 위험을 과장하지 마라.
+- 의학적 단정 표현은 피하고, "확인이 필요합니다", "주의가 필요합니다"처럼 작성해라.
+- JSON이 아니라 일반 문장만 반환해라.
+- 마크다운 코드블록을 사용하지 마라.
+
+의약품 정보:
+${JSON.stringify({ medicines, durList }, null, 2)}
+`;
+
+  const text = await requestGemini(prompt, {
+    maxOutputTokens: 300,
   });
 
-  if (!text) {
-    return '';
-  }
-
-  return parseSummary(text);
+  return String(text).trim();
 };
 
 module.exports = {
   extractMedicines,
-  summarizeMedicineBrief,
   extractMedicinesFallback,
+  summarizeMedicineBrief,
+  summarizeMedicinesBrief,
+  summarizePrescriptionBrief,
 };

--- a/utils/gemini.js
+++ b/utils/gemini.js
@@ -155,6 +155,41 @@ const extractMedicines = async (rawText) => {
   return parseCandidates(text);
 };
 
+const extractMedicinesFallback = (rawText) => {
+  if (!rawText || !rawText.trim()) return [];
+
+  const medicinePattern =
+    /[#]?[가-힣A-Za-z0-9]+(?:정|캡슐|시럽|현탁액|액|과립|산|주사|주|크림|연고|겔|패취|점안액)(?:\s?\[[^\]]+\])?/g;
+
+  const matches = rawText.match(medicinePattern) || [];
+
+  const excludeWords = [
+    "복약지도",
+    "약품명",
+    "먹는약",
+    "영수증",
+    "조제약",
+    "처방약",
+    "현금영수증",
+    "사업자등록번호",
+  ];
+
+  return [
+    ...new Set(
+      matches
+        .map((item) =>
+          item
+            .replace(/^#/, "")
+            .replace(/\s?\[.*?\]/g, "")
+            .trim()
+        )
+        .filter(Boolean)
+        .filter((item) => item.length >= 2)
+        .filter((item) => !excludeWords.some((word) => item.includes(word)))
+    ),
+  ];
+};
+
 const summarizeMedicineBrief = async ({ medicine, durList = [] }) => {
   if (!medicine) {
     return '';
@@ -183,4 +218,5 @@ const summarizeMedicineBrief = async ({ medicine, durList = [] }) => {
 module.exports = {
   extractMedicines,
   summarizeMedicineBrief,
+  extractMedicinesFallback,
 };

--- a/utils/medicineApi.js
+++ b/utils/medicineApi.js
@@ -2,6 +2,11 @@ const axios = require("axios");
 
 const API_KEY = process.env.MEDICINE_API_KEY;
 
+const getServiceKey = () => {
+  if (!API_KEY) return "";
+  return API_KEY.includes("%") ? decodeURIComponent(API_KEY) : API_KEY;
+};
+
 // 1차: e약은요 API
 const EASY_DRUG_URL =
   "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
@@ -15,10 +20,8 @@ const getItems = (data) => {
 
   if (!items) return [];
 
-  // JSON 응답이 배열로 올 때
   if (Array.isArray(items)) return items;
 
-  // XML 변환형/일부 API 응답에서 item으로 감싸질 때 대비
   if (Array.isArray(items.item)) return items.item;
   if (items.item) return [items.item];
 
@@ -27,19 +30,46 @@ const getItems = (data) => {
 
 const pick = (obj, keys) => {
   for (const key of keys) {
-    if (obj?.[key]) return obj[key];
+    if (obj?.[key] !== undefined && obj?.[key] !== null && obj?.[key] !== "") {
+      return obj[key];
+    }
   }
 
   return "";
+};
+
+const cleanDisplayName = (value = "") =>
+  String(value)
+    .replace(/\([^)]*\)/g, "")
+    .replace(/\[[^\]]*\]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const normalizeName = (value = "") =>
+  String(value)
+    .replace(/\([^)]*\)/g, "")
+    .replace(/\[[^\]]*\]/g, "")
+    .replace(/\s+/g, "")
+    .toLowerCase();
+
+const isMatchedMedicine = (apiName, keyword) => {
+  const name = normalizeName(apiName);
+  const query = normalizeName(keyword);
+
+  if (!name || !query) return false;
+
+  return name.includes(query) || query.includes(name);
 };
 
 async function fetchEasyDrugInfo(itemName) {
   try {
     console.log("[EASY DRUG API QUERY]", itemName);
 
+    const serviceKey = getServiceKey();
+
     const res = await axios.get(EASY_DRUG_URL, {
       params: {
-        serviceKey: API_KEY,
+        serviceKey,
         itemName,
         numOfRows: 1,
         pageNo: 1,
@@ -47,23 +77,33 @@ async function fetchEasyDrugInfo(itemName) {
       },
     });
 
-    // console.log("[EASY DRUG API RESPONSE]", JSON.stringify(res.data, null, 2));
-
     const item = getItems(res.data)[0];
+
     if (!item) return null;
 
-    // console.log("[PERMIT DRUG ITEM KEYS]", Object.keys(item));
-    // console.log("[PERMIT DRUG ITEM]", item);
-
     return {
-      name: item.itemName,
-      effect: item.efcyQesitm,
-      usage: item.useMethodQesitm,
-      caution: item.atpnQesitm,
-      interaction: item.intrcQesitm,
-      sideEffect: item.seQesitm,
-      storageMethod: item.depositMethodQesitm,
-      image: item.itemImage,
+      name: item.itemName || "",
+      normalizedName: cleanDisplayName(item.itemName || ""),
+
+      effect: item.efcyQesitm || "",
+      usage: item.useMethodQesitm || "",
+      dosage: item.useMethodQesitm || "",
+
+      caution: item.atpnQesitm || "",
+      interaction: item.intrcQesitm || "",
+      sideEffect: item.seQesitm || "",
+      storageMethod: item.depositMethodQesitm || "",
+      validTerm: "",
+      image: item.itemImage || "",
+
+      company: "",
+      ingredient: "",
+      permitDate: "",
+      className: "",
+      productType: "",
+      status: "",
+      ediCode: "",
+
       source: "easyDrug",
     };
   } catch (err) {
@@ -76,11 +116,13 @@ async function fetchPermitDrugInfo(itemName) {
   try {
     console.log("[PERMIT DRUG API QUERY]", itemName);
 
+    const serviceKey = getServiceKey();
+
     const res = await axios.get(PERMIT_DRUG_URL, {
       params: {
-        serviceKey: API_KEY,
-        itemName: itemName,
-        numOfRows: 1,
+        serviceKey,
+        item_name: itemName,
+        numOfRows: 10,
         pageNo: 1,
         type: "json",
       },
@@ -91,11 +133,40 @@ async function fetchPermitDrugInfo(itemName) {
       JSON.stringify(res.data, null, 2),
     );
 
-    const item = getItems(res.data)[0];
-    if (!item) return null;
+    const items = getItems(res.data);
 
-    const name = pick(item, ["itemName", "itemName", "itemName"]);
-    const company = pick(item, ["ENTP_NAME", "entp_name", "entpName"]);
+    console.log("[PERMIT DRUG ITEMS LENGTH]", items.length);
+    console.log("[PERMIT DRUG FIRST ITEM]", items[0]?.ITEM_NAME);
+
+    const item = items.find((item) => {
+      const name = pick(item, [
+        "ITEM_NAME",
+        "itemName",
+        "ITEM_NM",
+        "PRDLST_NM",
+      ]);
+      return isMatchedMedicine(name, itemName);
+    });
+
+    if (!item) {
+      console.warn("[PERMIT DRUG NO MATCH]", {
+        query: itemName,
+        totalCount: res.data?.body?.totalCount,
+        firstItem: items[0]?.ITEM_NAME,
+      });
+
+      return null;
+    }
+
+    const name = pick(item, ["ITEM_NAME", "itemName", "ITEM_NM", "PRDLST_NM"]);
+
+    const company = pick(item, [
+      "ENTP_NAME",
+      "entp_name",
+      "entpName",
+      "BIZRNO_NM",
+    ]);
+
     const ingredient = pick(item, [
       "ITEM_INGR_NAME",
       "item_ingr_name",
@@ -105,22 +176,32 @@ async function fetchPermitDrugInfo(itemName) {
       "main_item_ingr",
       "mainIngr",
     ]);
+
     const permitDate = pick(item, ["ITEM_PERMIT_DATE", "item_permit_date"]);
+
     const className = pick(item, [
       "SPCLTY_PBLC",
       "spclty_pblc",
       "ETC_OTC_CODE",
       "etc_otc_code",
     ]);
+
     const productType = pick(item, ["PRDUCT_TYPE", "prduct_type"]);
+
     const image = pick(item, ["BIG_PRDT_IMG_URL", "big_prdt_img_url"]);
+
     const status = pick(item, ["CANCEL_NAME", "cancel_name"]);
+
     const ediCode = pick(item, ["EDI_CODE", "edi_code"]);
 
     return {
       name,
+      normalizedName: cleanDisplayName(name),
+
       effect: productType || "",
       usage: "",
+      dosage: "",
+
       caution: "",
       sideEffect: "",
       image,
@@ -152,14 +233,13 @@ async function fetchMedicineInfo(itemName) {
       throw new Error("MEDICINE_API_KEY가 .env에 설정되지 않았습니다.");
     }
 
-    // 1차: e약은요 API
     const easyDrug = await fetchEasyDrugInfo(itemName);
     if (easyDrug) return easyDrug;
 
-    // 2차: 의약품 제품 허가정보 API
     const permitDrug = await fetchPermitDrugInfo(itemName);
     if (permitDrug) return permitDrug;
 
+    console.warn("[MEDICINE API NO RESULT]", itemName);
     return null;
   } catch (err) {
     console.error("[MEDICINE API ERROR]", err.response?.data || err.message);


### PR DESCRIPTION
## 작업 내용

### 1. 의약품 조회 API 개선

- `/api/medicine` 라우터에서 약품명 검색어 정제 로직을 추가했습니다.
- OCR/Gemini에서 추출된 약품명이 괄호, 공백, 불필요한 문자와 함께 들어와도 실제 약품명 기준으로 조회되도록 처리했습니다.
- `refresh=true` 또는 `refresh=1` 요청 시 기존 DB 데이터를 갱신할 수 있도록 처리했습니다.
- DB에 조회된 약품이 없을 경우 식약처 API를 호출해 데이터를 저장한 뒤 반환하도록 구성했습니다.

### 2. 식약처 의약품 API 연동 안정화

- e약은요 API와 의약품 제품 허가정보 API 조회 로직을 정리했습니다.
- 공공데이터 API 서비스키 처리 방식을 통일했습니다.
- 제품 허가정보 API 요청 파라미터를 실제 검색 파라미터 기준으로 수정했습니다.
- API 응답의 첫 번째 데이터를 무조건 사용하지 않고, 요청한 약품명과 실제 응답 약품명이 일치하는지 검증하도록 개선했습니다.
- 약품명에서 괄호 안 성분명을 제거한 `normalizedName`을 저장하도록 처리했습니다.
- 북마크 목록에서 사용할 수 있도록 `dosage`, `productType`, `status`, `ediCode` 등의 필드를 함께 저장하도록 보완했습니다.

### 3. 의약품 모델 필드 보완

- `Medicine` 모델에 북마크 및 화면 표시용 필드를 추가했습니다.
  - `dosage`
  - `productType`
  - `status`
  - `ediCode`
  - `normalizedName`
- 제품 허가정보 API와 e약은요 API에서 내려오는 데이터를 저장할 수 있도록 스키마를 보완했습니다.

### 4. 북마크 API 개선

- 북마크 목록 조회 시 약품 id를 기준으로 `Medicine` 데이터를 다시 조회해 최신 정보를 보강하도록 처리했습니다.
- 북마크 응답에 다음 필드가 포함되도록 개선했습니다.
  - `name`
  - `normalizedName`
  - `engName`
  - `category`
  - `dosage`
  - `warning`
- 북마크 추가 시 약품명, 정규화 이름, 분류, 복용법, 저장일을 함께 저장하도록 처리했습니다.
- 북마크 삭제와 수정은 약품 id 기준으로 동작하도록 유지했습니다.
- 북마크 폴더 이동 시 여러 폴더를 저장할 수 있도록 폴더 데이터를 배열 타입으로 처리했습니다.

### 5. 사용자 북마크 스키마 수정

- `User` 모델의 북마크 스키마를 수정했습니다.
- `folder` 필드를 문자열에서 문자열 배열로 변경했습니다.
  - 기존: `folder: String`
  - 변경: `folder: [String]`
- 북마크에 `normalizedName` 필드를 추가했습니다.
- 폴더 이동 시 배열 데이터가 저장되도록 스키마 타입을 맞췄습니다.

### 6. DUR 병용금기 조회 API 개선

- `/api/dur/product` 요청 시 품목명에서 괄호 안 성분명을 제거한 뒤 조회하도록 처리했습니다.
  - 예: `맥페란정(메토클로프라미드)` → `맥페란정`
- DUR 성분 기준 조회와 품목명 기준 조회 라우터를 분리했습니다.
- DUR API 응답 필드명이 다양하게 내려오는 경우를 대비해 공통 포맷으로 정규화했습니다.
- 중복 병용금기 데이터를 제거해 화면에서 중복 표시되지 않도록 처리했습니다.

### 7. 처방전 스캔 API 개선

- `/api/scan` 라우터에서 OCR 결과를 기반으로 약품명 후보를 추출하도록 처리했습니다.
- Gemini를 이용해 약품명 후보를 추출하고, 실패 시 fallback 정규식으로 후보를 추출하도록 구성했습니다.
- 환자 정보, 금액, 복용 일수, 제형 단독 표현 등 약품명이 아닌 텍스트를 필터링했습니다.
- 최종 후보는 중복 제거 후 `candidates` 배열로 반환하도록 정리했습니다.

### 8. 약품 요약 API 추가 및 fallback 처리

- 단일 약품 요약 API와 여러 약품 일괄 요약 API를 구성했습니다.
- `/api/summary/medicines`에서 여러 약품의 복용 전 주의사항을 한 번에 요약하도록 처리했습니다.
- Gemini 요약 실패 시 기본 fallback 요약을 반환하도록 처리했습니다.
- 제품 허가정보 기준 약품, DUR 병용금기 정보, 졸음/운전 주의, 알레르기 관련 주의사항 등을 기준으로 fallback 문구를 분기했습니다.

### 9. Gemini 유틸 로직 개선

- OCR 텍스트에서 약품명만 JSON 배열로 추출하는 함수를 구성했습니다.
- Gemini 응답이 JSON 형식으로 오도록 설정하고, 응답 파싱 로직을 추가했습니다.
- 약품별 복용 전 주의사항을 쉬운 문장으로 요약하는 일괄 요약 함수를 추가했습니다.
- Gemini 응답 파싱 실패 시 빈 배열을 반환해 서버 오류로 이어지지 않도록 처리했습니다.

## 주요 변경 파일

- `routes/medicine.js`
- `routes/scan.js`
- `routes/dur.js`
- `routes/summary.js`
- `utils/medicineApi.js`
- `utils/durApi.js`
- `utils/gemini.js`
- `models/Medicine.js`
- `models/User.js`

## 확인 사항

- [x] `/api/scan` 요청 시 OCR 텍스트와 약품명 후보가 반환되는지 확인
- [x] Gemini 약품명 추출 실패 시 fallback 후보 추출이 동작하는지 확인
- [x] `/api/medicine?q=약품명` 요청 시 DB 조회 후 없으면 식약처 API 조회가 동작하는지 확인
- [x] 제품 허가정보 API에서 검색어와 일치하는 약품만 저장되는지 확인
- [x] `normalizedName`이 괄호 제거된 약품명으로 저장되는지 확인
- [x] 북마크 추가 시 약품 정보와 저장일이 함께 저장되는지 확인
- [x] 북마크 삭제 시 약품 id 기준으로 정상 삭제되는지 확인
- [x] 북마크 폴더 이동 시 배열 형태로 저장되는지 확인
- [x] DUR 조회 시 괄호 안 성분명을 제거한 품목명으로 조회되는지 확인
- [x] DUR 응답 데이터가 화면에서 사용 가능한 형태로 정규화되는지 확인
- [x] 약품 요약 실패 시 fallback 문구가 반환되는지 확인