### PR TITLE
[feature] AI 분석 기록 이름 변경 API 추가

### DIFF
--- a/models/AnalysisRecord.js
+++ b/models/AnalysisRecord.js
@@ -7,6 +7,7 @@ const analysisRecordSchema = new mongoose.Schema(
     medicineCount:  { type: Number, default: 0 },
     cautionCount:   { type: Number, default: 0 }, // durList가 있는 약품 수
     medicineResults: [{ type: mongoose.Schema.Types.Mixed }],
+    title:          { type: String, default: null },
     isPinned:       { type: Boolean, default: false },
     pinnedAt:       { type: Date, default: null },
   },

--- a/routes/analysis.js
+++ b/routes/analysis.js
@@ -34,7 +34,7 @@ router.post('/', authMiddleware, async (req, res) => {
 router.get('/', authMiddleware, async (req, res) => {
   try {
     const records = await AnalysisRecord.find({ userId: req.user.id })
-    .select('candidates medicineCount cautionCount createdAt isPinned pinnedAt')
+    .select('candidates medicineCount cautionCount createdAt title isPinned pinnedAt')
     .sort({ isPinned: -1, pinnedAt: -1, createdAt: -1 });
 
     return res.json(records);
@@ -59,7 +59,7 @@ router.patch('/:id/title', authMiddleware, async (req, res) => {
     const record = await AnalysisRecord.findOneAndUpdate(
         { _id: req.params.id, userId: req.user.id },
         { title },
-        { new: true, select: 'title' },
+        { returnDocument: 'after', select: 'title' },
     );
 
     if (!record) return res.status(404).json({ error: '기록을 찾을 수 없습니다.' });

--- a/routes/analysis.js
+++ b/routes/analysis.js
@@ -34,13 +34,40 @@ router.post('/', authMiddleware, async (req, res) => {
 router.get('/', authMiddleware, async (req, res) => {
   try {
     const records = await AnalysisRecord.find({ userId: req.user.id })
-      .select('candidates medicineCount cautionCount createdAt isPinned pinnedAt')
-      .sort({ isPinned: -1, pinnedAt: -1, createdAt: -1 });
+    .select('candidates medicineCount cautionCount createdAt title isPinned pinnedAt')
+    .sort({ isPinned: -1, pinnedAt: -1, createdAt: -1 });
 
     return res.json(records);
   } catch (err) {
     console.error('[ANALYSIS LIST ERROR]', err);
     res.status(500).json({ error: '목록을 불러오지 못했습니다.' });
+  }
+});
+
+// PATCH /api/analysis/:id/title - 이름 변경
+router.patch('/:id/title', authMiddleware, async (req, res) => {
+  try {
+    const title = req.body.title?.trim();
+
+    if (!title) {
+      return res.status(400).json({ error: '제목을 입력해주세요.' });
+    }
+    if (title.length > 50) {
+      return res.status(400).json({ error: '제목은 50자 이하로 입력해주세요.' });
+    }
+
+    const record = await AnalysisRecord.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user.id },
+        { title },
+        { new: true, select: 'title' },
+    );
+
+    if (!record) return res.status(404).json({ error: '기록을 찾을 수 없습니다.' });
+
+    return res.json({ title: record.title });
+  } catch (err) {
+    console.error('[ANALYSIS RENAME ERROR]', err);
+    res.status(500).json({ error: '이름 변경에 실패했습니다.' });
   }
 });
 


### PR DESCRIPTION
## Summary
close  #10
- `AnalysisRecord` 스키마에 `title` 필드 추가 (nullable)
- `PATCH /api/analysis/:id/title` 엔드포인트 추가
- `GET /api/analysis` 응답 select에 `title` 포함

## 변경 파일
- `models/AnalysisRecord.js` — title 필드 추가
- `routes/analysis.js` — rename 엔드포인트 추가, 목록 select 수정

## API 명세
```
PATCH /api/analysis/:id/title
Authorization: Bearer {token}
Body: { "title": "새 이름" }

200: { "title": "새 이름" }
400: 빈 값 또는 50자 초과
404: 기록 없음 또는 타인 기록 접근
```
